### PR TITLE
Add support for object patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ module.exports = {
         // Multiple patterns and negation supported. See https://github.com/mrmlnc/fast-glob
         patterns: [`*`, `!*.md`]
       }
+    },
+    {
+      resolve: `gatsby-source-git`,
+      options: {
+        name: `repo-three`,
+        remote: `https://bitbucket.org/stevetweeddale/markdown-test.git`,
+        // Multiple "sourceInstanceName" on the same repo via object.
+        patterns: {
+          articles: `docs/articles/*.md`,
+          authors: `docs/authors/*.md`,
+        }
+      }
     }
   ]
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -38,7 +38,7 @@ async function getRepo(path, remote, branch) {
       .then(() => repo.reset([`--hard`, target]));
     return repo;
   } else {
-    throw new Error(`Can't clone to target destination: ${localPath}`);
+    throw new Error(`Can't clone to target destination: ${path}`);
   }
 }
 


### PR DESCRIPTION
segregate `"sourceInstanceName"` based on object keys, while reusing the repo on the disk. Downside: non-exclusive queries can clash.