### PR TITLE
Fix an issue causing trailing '\n' to mess up reset command.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,7 +13,7 @@ async function getTargetBranch(repo, branch) {
   if (typeof branch == `string`) {
     return `origin/${branch}`;
   } else {
-    return repo.raw(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+    return repo.raw(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]).then(result => result.trim());
   }
 }
 


### PR DESCRIPTION
Encountered this issue on Windows, causing the reset command to fail.