### PR TITLE
Feature/override local location

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ module.exports = {
         remote: `https://bitbucket.org/stevetweeddale/markdown-test.git`,
         // Optionally supply a branch. If none supplied, you'll get the default branch.
         branch: `develop`,
+
         // (Optional) Specify a local path for the repo. If omitted, it will
         // default to using a directory within the local Gatsby cache.
-        local: '/explicit/path/to/repo-one'
+        // local: '/explicit/path/to/repo-one',
+
         // Tailor which files get imported eg. import the docs folder from a codebase.
         patterns: `docs/**`
       }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ module.exports = {
         remote: `https://bitbucket.org/stevetweeddale/markdown-test.git`,
         // Optionally supply a branch. If none supplied, you'll get the default branch.
         branch: `develop`,
+        // (Optional) Specify a local path for the repo. If omitted, it will
+        // default to using a directory within the local Gatsby cache.
+        local: '/explicit/path/to/repo-one'
         // Tailor which files get imported eg. import the docs folder from a codebase.
         patterns: `docs/**`
       }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -49,10 +49,10 @@ exports.sourceNodes = async (
     createContentDigest,
     reporter
   },
-  { name, remote, branch, patterns = `**` }
+  { name, remote, branch, patterns = `**`, local }
 ) => {
   const programDir = store.getState().program.directory;
-  const localPath = require("path").join(
+  const localPath = local || require("path").join(
     programDir,
     `.cache`,
     `gatsby-source-git`,


### PR DESCRIPTION
This will let users have the option of checking out (or just using) a repo into a place outside the Gatsby .cache directory. This is potentially useful in CI environments and/or when doing local dev work to avoid re-checking out repositories when Gatsby clears its cache.