### PR TITLE
Feature/contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,21 @@ module.exports = {
         // Optionally supply a branch. If none supplied, you'll get the default branch.
         branch: `develop`,
         // Tailor which files get imported eg. import the docs folder from a codebase.
-        patterns: `docs/**`
+        patterns: `docs/**`,
+
+        // (Optional) Collect the contributor list for the repo and/or for each
+        // file that is checked out. This will be available to Gatsby queries
+        // as part of the File node (see below). Note: for larger repository
+        // histories this operation may take a bit. Also, the default checkout
+        // depth is 1, so unless you change it, you'll only ever see the last
+        // contributor when using the 'path' option.
+
+        // Options are:
+        //    undefined/false - Do not collect contributor records (Default)
+        //    'repo'          - Collect contributors only for the repo itself
+        //    'path'          - Collect contributors for each file
+        //    'all'           - Perform both 'repo' and 'path' collection
+        // contributors: false,
       }
     },
     {
@@ -116,3 +130,40 @@ And access some information about the git repo:
   }
 }
 ```
+
+### Querying for Contributors
+
+Contributions are obtained directly from the git log, summarized, and made available to the GraphQL language as part of the File node created (or for the repo itself). The available fields are (again, according to the git log):
+
+* `count` - The number of commits/contributions for this person
+* `name` - The name of this contributor (e.g. "Jane Developer")
+* `email` - The email address for the contributor (e.g. jane@company.com)
+
+> Note: By default this plugin only performs a shallow checkout (e.g. `--depth 1`) so you will only get the latest contributor for each file if using the `contributors: path` plugin option above.
+
+```graphql
+{
+  allFile {
+    edges {
+      node {
+        gitContributors {
+          count
+          name
+          email
+        }
+        gitRemote {
+          webLink
+          ref
+          gitContributors {
+            count
+            name
+            email
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Further, the underlying git command is capable of doing some amount of person-matching in order to clean up the contributors list and merge authors in a noisy history via a `.mailmap` file. Please see the [documentation for git shortlog](https://git-scm.com/docs/git-shortlog) for futher details.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ module.exports = {
         // Optionally supply a branch. If none supplied, you'll get the default branch.
         branch: `develop`,
 
-        // (Optional) Configure the checkout/fetch depth when refreshing from
-        // upstream repository. To fetch the entire history, use 'all' here.
-        // The default is to perform a shallow clone (i.e. depth = 1).
-        // depth: 1,
-
         // Tailor which files get imported eg. import the docs folder from a codebase.
         patterns: `docs/**`,
 
@@ -68,6 +63,11 @@ module.exports = {
         //    'path'          - Collect contributors for each file
         //    'all'           - Perform both 'repo' and 'path' collection
         // contributors: false,
+
+        // (Optional) Configure the checkout/fetch depth when refreshing from
+        // upstream repository. To fetch the entire history, use 'all' here.
+        // The default is to perform a shallow clone (i.e. depth = 1).
+        // depth: 1,
       }
     },
     {
@@ -145,7 +145,7 @@ Contributions are obtained directly from the git log, summarized, and made avail
 * `name` - The name of this contributor (e.g. "Jane Developer")
 * `email` - The email address for the contributor (e.g. jane@company.com)
 
-> Note: By default this plugin only performs a shallow checkout (e.g. `--depth 1`) so you will only get the latest contributor for each file if using the `contributors: path` plugin option above.
+> Note: By default this plugin only performs a shallow checkout (e.g. `--depth 1`) so you will only get the latest contributor for each file if using the `contributors: path` plugin option above. Use the `depth: all` option (or some other value) to get more than just the latest log entries.
 
 ```graphql
 {

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ module.exports = {
         remote: `https://bitbucket.org/stevetweeddale/markdown-test.git`,
         // Optionally supply a branch. If none supplied, you'll get the default branch.
         branch: `develop`,
+
+        // (Optional) Configure the checkout/fetch depth when refreshing from
+        // upstream repository. To fetch the entire history, use 'all' here.
+        // The default is to perform a shallow clone (i.e. depth = 1).
+        // depth: 1,
+
         // Tailor which files get imported eg. import the docs folder from a codebase.
         patterns: `docs/**`,
 


### PR DESCRIPTION
Use `git shortlog` to expose the contributors list both at a repo level and/or an individual file level. This is useful for sites that may want to highlight the maintainers and/or authors on a per-page basis.

It also allows the fetch depth to be overridden so that contributions older than the most recent one can be obtained.

