### PR TITLE
Override file modifiedTime by git commit history

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ module.exports = {
         remote: `https://bitbucket.org/stevetweeddale/markdown-test.git`,
         branch: `develop`,
         // Only import the docs folder from a codebase.
-        patterns: `docs/**`
+        patterns: `docs/**`,
+        // The "--depth" command line argument of Git. Set to 0 if you need accurate file modified time.
+        fetchDepth: 1
       }
     },
     {
@@ -113,6 +115,8 @@ eg:
         extension
         dir
         modifiedTime
+        message
+        authorName
       }
     }
   }
@@ -130,6 +134,8 @@ Similarly, you can filter by the `name` you specified in the config by using
         extension
         dir
         modifiedTime
+        message
+        authorName
       }
     }
   }


### PR DESCRIPTION
Override the modifiedTime by git commit history.

1. Add option "enableShallowClone" to enable/disable shallow clone
2. When enableShallowClone is false, clone without "--depth 1" so that we can retrieve real commit time for a file