### PR TITLE
fixed https://github.com/stevetweeddale/gatsby-source-git/issues/22

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -105,9 +105,7 @@ exports.sourceNodes = async (
       fileNode.gitRemote___NODE = remoteId;
       // Then create the node, as if it were created by the gatsby-source
       // filesystem plugin.
-      return createNode(fileNode, {
-        name: `gatsby-source-filesystem`
-      });
+      return createNode(fileNode);
     });
   };
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,8 @@
 // noop
+const fs = require(`fs-extra`)
+
+function loadNodeContent(fileNode) {
+  return fs.readFile(fileNode.absolutePath, `utf-8`)
+}
+
+exports.loadNodeContent = loadNodeContent

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/stevetweeddale/gatsby-source-git#readme",
   "dependencies": {
     "fast-glob": "^2.2.3",
-    "fs-extra": "^5.0.0",
+    "fs-extra": "^8.1.0",
     "gatsby-source-filesystem": "^2.1.19",
     "git-url-parse": "^11.1.1",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
fixed https://github.com/stevetweeddale/gatsby-source-git/issues/22
because the `loadNodeContent` function in *gatsby-transformer-remark* need *gatsby-source-git* to imply.
but in this plugin, don't have this function.

we can add this function in index.js at root. and handle file content use `fs-extra`.

so, dont need *gatsby-source-filesystem* anymore.

tested in my project.