### PR TITLE
feat: Make the configured patterns queryable

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -86,6 +86,7 @@ exports.sourceNodes = async (
     Object.assign(parsedRemote, {
       id: remoteId,
       sourceInstanceName: name,
+      patterns,
       parent: null,
       children: [],
       internal: {


### PR DESCRIPTION
This change makes it possible to tell how the pattern option was configured for any `GitRemote` type. This is helpful for creating slugs for pages and knowing the `basePath` to pass to `createFilePath`. For example:

```js
const globBase = require('glob-base');
const {createFilePath} = require('gatsby-source-filesystem');

exports.onCreateNode = ({node, getNode, actions}) => {
  const {type} = node.internal;
  if (type === 'MarkdownRemark' || type === 'Mdx') {
    const {gitRemote___NODE} = getNode(node.parent);
    const {patterns} = getNode(gitRemote___NODE);
    const {base} = globBase(patterns);
    const filePath = createFilePath({
      node,
      getNode,
      basePath: base
    });
  }
};
```